### PR TITLE
build: Dex-preopt boot image by default on userdebug

### DIFF
--- a/core/dex_preopt.mk
+++ b/core/dex_preopt.mk
@@ -25,19 +25,19 @@ SYSTEM_OTHER_ODEX_FILTER ?= app/% priv-app/%
 
 # The default values for pre-opting: always preopt PIC.
 # Conditional to building on linux, as dex2oat currently does not work on darwin.
-#ifeq ($(HOST_OS),linux)
-#  WITH_DEXPREOPT_PIC ?= true
-#  WITH_DEXPREOPT ?= true
+ifeq ($(HOST_OS),linux)
+  WITH_DEXPREOPT_PIC ?= true
+  WITH_DEXPREOPT ?= true
 # For an eng build only pre-opt the boot image. This gives reasonable performance and still
 # allows a simple workflow: building in frameworks/base and syncing.
-#  ifeq (eng,$(TARGET_BUILD_VARIANT))
-#    WITH_DEXPREOPT_BOOT_IMG_ONLY ?= true
-#  endif
+  ifneq (user,$(TARGET_BUILD_VARIANT))
+    WITH_DEXPREOPT_BOOT_IMG_ONLY ?= true
+  endif
 # Add mini-debug-info to the boot classpath unless explicitly asked not to.
-#  ifneq (false,$(WITH_DEXPREOPT_DEBUG_INFO))
-#    PRODUCT_DEX_PREOPT_BOOT_FLAGS += --generate-mini-debug-info
-#  endif
-#endif
+  ifneq (false,$(WITH_DEXPREOPT_DEBUG_INFO))
+    PRODUCT_DEX_PREOPT_BOOT_FLAGS += --generate-mini-debug-info
+  endif
+endif
 
 GLOBAL_DEXPREOPT_FLAGS :=
 ifeq ($(WITH_DEXPREOPT_PIC),true)


### PR DESCRIPTION
Instead of completely disabling dex-preopt on userdebug,
only dex-preopt the boot image on userdebug.

This gets us closer to AOSP's config without compromising
on ease of development.

This partially reverts commit 6f9c2e115aeccd7090f92f1fb91bc6052522cdd1.

Change-Id: Ibecfa0377947749eddc573fd264799030c54ea80