### PR TITLE
build: Conditionally disable ccache for modules with FDO enabled

### DIFF
--- a/core/binary.mk
+++ b/core/binary.mk
@@ -313,10 +313,32 @@ ifneq ($(filter true always, $(LOCAL_FDO_SUPPORT)),)
     my_cflags += $($(LOCAL_2ND_ARCH_VAR_PREFIX)TARGET_FDO_OPTIMIZE_CFLAGS)
     my_fdo_build := true
   endif
-  # Disable ccache (or other compiler wrapper) except gomacc, which
-  # can handle -fprofile-use properly.
-  my_cc_wrapper := $(filter $(GOMA_CC),$(my_cc_wrapper))
-  my_cxx_wrapper := $(filter $(GOMA_CC),$(my_cxx_wrapper))
+  # Disable ccache (or other compiler wrapper) except gomacc, unless
+  # it can handle -fprofile-use properly.
+
+  # ccache supports -fprofile-use as of version 3.2. Parse the version output
+  # of each wrapper to determine if it's ccache 3.2 or newer.
+  is_cc_ccache := $(shell if [ "`$(my_cc_wrapper) -V 2>/dev/null | head -1 | cut -d' ' -f1`" = ccache ]; then echo true; fi)
+  ifeq ($(is_cc_ccache),true)
+    cc_ccache_version := $(shell $(my_cc_wrapper) -V | head -1 | grep -o '[[:digit:]]\+\.[[:digit:]]\+')
+    vmajor := $(shell echo $(cc_ccache_version) | cut -d'.' -f1)
+    vminor := $(shell echo $(cc_ccache_version) | cut -d'.' -f2)
+    cc_ccache_ge_3_2 = $(shell if [ $(vmajor) -gt 3 -o $(vmajor) -eq 3 -a $(vminor) -ge 2 ]; then echo true; fi)
+  endif
+  is_cxx_ccache := $(shell if [ "`$(my_cxx_wrapper) -V 2>/dev/null | head -1 | cut -d' ' -f1`" = ccache ]; then echo true; fi)
+  ifeq ($(is_cxx_ccache),true)
+    cxx_ccache_version := $(shell $(my_cxx_wrapper) -V | head -1 | grep -o '[[:digit:]]\+\.[[:digit:]]\+')
+    vmajor := $(shell echo $(cxx_ccache_version) | cut -d'.' -f1)
+    vminor := $(shell echo $(cxx_ccache_version) | cut -d'.' -f2)
+    cxx_ccache_ge_3_2 = $(shell if [ $(vmajor) -gt 3 -o $(vmajor) -eq 3 -a $(vminor) -ge 2 ]; then echo true; fi)
+  endif
+
+  ifneq ($(cc_ccache_ge_3_2),true)
+    my_cc_wrapper := $(filter $(GOMA_CC),$(my_cc_wrapper))
+  endif
+  ifneq ($(cxx_ccache_ge_3_2),true)
+    my_cxx_wrapper := $(filter $(GOMA_CC),$(my_cxx_wrapper))
+  endif
 endif
 
 ###########################################################


### PR DESCRIPTION
ccache supports the compiler option -fprofile-use since v3.2. If the
current wrapper is ccache v3.2 or newer, don't disable it when FDO
is turned on.

Change-Id: I506010173f60b791eae0d65afeac36995c57dbe6